### PR TITLE
Reduce demo resource usage

### DIFF
--- a/hack/sample/instance_1.yaml
+++ b/hack/sample/instance_1.yaml
@@ -26,11 +26,11 @@ spec:
           value: ENV_VAR_VALUE
       resources:
         requests:
-          cpu: "0.5"
-          memory: "500Mi"
+          cpu: "0.1"
+          memory: "256Mi"
         limits:
-          cpu: "0.5"
-          memory: "500Mi"
+          cpu: "0.3"
+          memory: "384Mi"
     sidecarContainer:
       #name: sidecar
       image: kdbdeveloper/mysql-sidecar:v0.0.10
@@ -41,11 +41,11 @@ spec:
           value: ENV_VAR_VALUE
       resources:
         requests:
-          cpu: "0.1"
-          memory: "100Mi"
+          cpu: "0.025"
+          memory: "64Mi"
         limits:
-          cpu: "0.5"
-          memory: "1024Mi"
+          cpu: "0.1"
+          memory: "128Mi"
     dataVolumeClaimSpec:
       storageClass: standard
       size: 1Gi
@@ -69,11 +69,11 @@ spec:
               key: password
       resources:
         requests:
+          cpu: "0.01"
+          memory: "32Mi"
+        limits:
           cpu: "0.05"
           memory: "64Mi"
-        limits:
-          cpu: "0.1"
-          memory: "128Mi"
   shutdown: false
   supplementalGroups:
     - 1000

--- a/hack/sample/operator/deploy.yaml
+++ b/hack/sample/operator/deploy.yaml
@@ -33,13 +33,13 @@ spec:
             - operator
           ports:
             - containerPort: 8081
-#          resources:
-#            limits:
-#              cpu: "0.5"
-#              memory: "128Mi"
-#            requests:
-#              cpu: "0.5"
-#              memory: "128Mi"
+          resources:
+            requests:
+              cpu: "0.01"
+              memory: "32Mi"
+            limits:
+              cpu: "0.1"
+              memory: "128Mi"
           readinessProbe:
             httpGet:
               path: /readyz
@@ -54,4 +54,3 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
             failureThreshold: 5
-

--- a/internal/config/tmpl/ini_mysql8.tmpl
+++ b/internal/config/tmpl/ini_mysql8.tmpl
@@ -59,10 +59,10 @@ plugin-load-add=auth_socket.so
 sql_mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION
 # innodb buffer
 innodb_buffer_pool_chunk_size=33554432  # 32MiB
-innodb_buffer_pool_instances=8
+innodb_buffer_pool_instances=1
 
 # InnoDB缓冲池大小，这是InnoDB性能的关键参数，用于缓存数据和索引，应该根据服务器内存合理设置，一般建议设置为服务器内存的70-80%左右
-innodb_buffer_pool_size=805306368
+innodb_buffer_pool_size=134217728
 # 连接缓冲区大小，用于每个连接处理查询时的缓存，适当增大可以提高性能
 join_buffer_size=262144
 # 排序缓冲区大小，用于处理排序操作，增加这个值可以提高排序性能，但也会消耗更多内存


### PR DESCRIPTION
## Summary
- add explicit lightweight resource requests/limits to sample operator deployment
- reduce sample MySQL demo database, sidecar, and exporter CPU/memory settings
- reduce MySQL 8 template buffer pool from 768Mi to 128Mi and use one buffer pool instance

## Verification
- ran `git diff --check`
- ran `kubectl apply --dry-run=client -f hack/sample/operator/deploy.yaml`
- ran `kubectl apply --dry-run=client -f hack/sample/instance_1.yaml`

## Notes
- live cluster operator resources and demo KDBInstance were updated separately during testing