### PR TITLE
fix: keep pending instance runners during reconcile

### DIFF
--- a/pkg/reconcile/steps/instance_step.go
+++ b/pkg/reconcile/steps/instance_step.go
@@ -482,6 +482,12 @@ func getNamesNeedToKeep(rc *context.InstanceContext) sets.String {
 			namesToKeep.Insert(ins.Name)
 		}
 	}
+	for _, ins := range observedInstances.List {
+		if namesToKeep.Len() >= int(wantNums) {
+			break
+		}
+		namesToKeep.Insert(ins.Name)
+	}
 	return namesToKeep
 }
 


### PR DESCRIPTION
## Summary
- keep pending StatefulSets within desired replica count during scale-down selection
- prevents newly created demo runners from being immediately deleted before Pods stabilize

## Verification
- built operator image locally as kdbdeveloper/operator:v0.0.25-localfix
- loaded image into kind-kdb and rolled out operator deployment
- demo StatefulSet/PVC reached stable creation after deleting stale StatefulSet
- go test ./... currently fails in existing internal/security tests unrelated to this change

## Risk
- low scoped reconcile behavior change; keeps existing runner names up to desired count when no master/non-master Pod can be identified yet