### PR TITLE
Fix KDBInstance shutdown reconcile

### DIFF
--- a/apis/kdb.com/v1/kdbinstance_types.go
+++ b/apis/kdb.com/v1/kdbinstance_types.go
@@ -73,8 +73,9 @@ type KDBInstanceSpec struct {
 	// +optional
 	MySQL *MySQLSpec `json:"mysql,omitempty"`
 
-	// Whether or not the kdb instance should be stopped.
-	// set statefulset replicas = 0 to deleting pod, but keep pvc
+	// Shutdown requests a logical stop of the KDB instance.
+	// When true, StatefulSet pods are scaled to zero while PVCs and other
+	// persistent resources remain in place for a later start.
 	// +optional
 	Shutdown *bool `json:"shutdown,omitempty"`
 

--- a/internal/generate/instance_statefulset.go
+++ b/internal/generate/instance_statefulset.go
@@ -72,11 +72,7 @@ func InstanceStatefulSetIntent(rc *context.InstanceContext, sts *appsv1.Stateful
 		sts.Spec.Template.Spec.PriorityClassName = *instanceSet.PriorityClassName
 	}
 
-	if instance.Spec.Shutdown != nil && *instance.Spec.Shutdown {
-		sts.Spec.Replicas = util.Int32(0)
-	} else {
-		sts.Spec.Replicas = util.Int32(1)
-	}
+	sts.Spec.Replicas = instanceStatefulSetReplicas(instance)
 
 	// Restart containers any time they stop, die, are killed, etc.
 	// - https://docs.k8s.io/concepts/workloads/pods/pod-lifecycle/#restart-policy
@@ -97,6 +93,13 @@ func InstanceStatefulSetIntent(rc *context.InstanceContext, sts *appsv1.Stateful
 
 	sts.Spec.Template.Spec.SecurityContext = security.PodSecurityContext(instance)
 
+}
+
+func instanceStatefulSetReplicas(instance *v1.KDBInstance) *int32 {
+	if instance.Spec.Shutdown != nil && *instance.Spec.Shutdown {
+		return util.Int32(0)
+	}
+	return util.Int32(1)
 }
 
 // instanceSetRole maps the topology role of a StatefulSet ordinal into legacy label roles.

--- a/internal/generate/instance_statefulset_test.go
+++ b/internal/generate/instance_statefulset_test.go
@@ -1,0 +1,38 @@
+package generate
+
+import (
+	"testing"
+
+	v1 "github.com/sqc157400661/kdb/apis/kdb.com/v1"
+)
+
+func TestInstanceStatefulSetReplicasFromShutdown(t *testing.T) {
+	tests := []struct {
+		name     string
+		shutdown *bool
+		want     int32
+	}{
+		{name: "nil shutdown starts pod", shutdown: nil, want: 1},
+		{name: "false shutdown starts pod", shutdown: boolPtr(false), want: 1},
+		{name: "true shutdown stops pod", shutdown: boolPtr(true), want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &v1.KDBInstance{}
+			instance.Spec.Shutdown = tt.shutdown
+
+			replicas := instanceStatefulSetReplicas(instance)
+			if replicas == nil {
+				t.Fatalf("expected replicas to be set")
+			}
+			if got := *replicas; got != tt.want {
+				t.Fatalf("unexpected replicas: got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/pkg/reconcile/steps/instance_step.go
+++ b/pkg/reconcile/steps/instance_step.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	v1 "github.com/sqc157400661/kdb/apis/kdb.com/v1"
 	"github.com/sqc157400661/kdb/apis/shared"
 	"github.com/sqc157400661/kdb/internal/config"
 	"github.com/sqc157400661/kdb/internal/naming"
@@ -476,16 +477,12 @@ func (s *InstanceStepManager) ScaleUpInstance() kube.BindFunc {
 		"ScaleUpInstance",
 		func(rc *context.InstanceContext, flow kube.Flow) (reconcile.Result, error) {
 			instance := rc.GetInstance()
-			observedInstances := rc.GetObservedRunner()
-			// Range over instance sets to scale up and ensure that each set has
-			// at least the number of replicas defined in the spec. The set can
-			// have more replicas than defined
+			// Reconcile every desired StatefulSet, including existing sets, so
+			// spec-only changes such as shutdown can update their pod replicas.
 			var runners []*appsv1.StatefulSet
-			existNum := len(observedInstances.List)
-			for existNum < int(*instance.Spec.InstanceSet.Replicas) {
-				next := naming.GenerateInstanceStatefulSetMeta(instance, existNum)
+			for i := 0; i < int(*instance.Spec.InstanceSet.Replicas); i++ {
+				next := naming.GenerateInstanceStatefulSetMeta(instance, i)
 				runners = append(runners, &appsv1.StatefulSet{ObjectMeta: next})
-				existNum++
 			}
 			var err error
 			for n := range runners {
@@ -527,6 +524,9 @@ func getNamesNeedToKeep(rc *context.InstanceContext) sets.String {
 	// want defines the number of replicas we want for each instance set
 	wantNums := *naming.InstanceSetSpec(instance).Replicas
 	namesToKeep := sets.NewString()
+	if instance.Spec.Shutdown != nil && *instance.Spec.Shutdown {
+		return stoppedInstanceStatefulSetNames(instance)
+	}
 	if wantNums > 0 {
 		for _, ins := range observedInstances.List {
 			if len(ins.Pods) > 0 && naming.IsMasterPod(ins.Pods[0]) {
@@ -541,6 +541,17 @@ func getNamesNeedToKeep(rc *context.InstanceContext) sets.String {
 		}
 	}
 	return namesToKeep
+}
+
+func stoppedInstanceStatefulSetNames(instance *v1.KDBInstance) sets.String {
+	names := sets.NewString()
+	if instance == nil || instance.Spec.InstanceSet.Replicas == nil {
+		return names
+	}
+	for i := 0; i < int(*instance.Spec.InstanceSet.Replicas); i++ {
+		names.Insert(naming.InstanceStatefulSetName(instance.Name, i))
+	}
+	return names
 }
 
 // deleteSts will delete all resources related to a single sts

--- a/pkg/reconcile/steps/instance_step_test.go
+++ b/pkg/reconcile/steps/instance_step_test.go
@@ -1,0 +1,24 @@
+package steps
+
+import (
+	"testing"
+
+	v1 "github.com/sqc157400661/kdb/apis/kdb.com/v1"
+	"github.com/sqc157400661/kdb/apis/shared"
+	"github.com/sqc157400661/util"
+)
+
+func TestStoppedInstanceStatefulSetNamesKeepsDesiredSets(t *testing.T) {
+	instance := &v1.KDBInstance{}
+	instance.Name = "demo"
+	instance.Spec.InstanceSet = shared.InstanceSetSpec{Replicas: util.Int32(2)}
+
+	names := stoppedInstanceStatefulSetNames(instance)
+
+	if !names.Has("demo0") || !names.Has("demo1") {
+		t.Fatalf("expected stopped desired StatefulSets to be kept, got %v", names.List())
+	}
+	if names.Has("demo2") {
+		t.Fatalf("expected extra StatefulSet demo2 not to be kept")
+	}
+}


### PR DESCRIPTION
## Summary
- keep logical stop semantics clear for spec.shutdown
- re-apply existing StatefulSets so shutdown toggles update replicas
- keep desired StatefulSet names during shutdown scale-down and add unit coverage

## Verification
- go test ./internal/generate ./pkg/reconcile/steps ./pkg/reconcile/steps/mysql
- go test ./... (fails in existing internal/security assertions unrelated to this change)