### PR TITLE
feat: project mysql parameter report config

### DIFF
--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -21,9 +21,28 @@ const (
 )
 
 type GlobalConfig struct {
-	DB                  DBConfig       `json:"db" yaml:"db"`
-	MySQLInstanceConfig InstanceConfig `json:"mysql_instance_config" yaml:"mysql_instance_config"`
-	HostResolveMode     string         `json:"host_resolve_mode" yaml:"host_resolve_mode"`
+	DB                  DBConfig              `json:"db" yaml:"db"`
+	MySQLInstanceConfig InstanceConfig        `json:"mysql_instance_config" yaml:"mysql_instance_config"`
+	HostResolveMode     string                `json:"host_resolve_mode" yaml:"host_resolve_mode"`
+	ParameterReport     ParameterReportConfig `json:"parameter_report" yaml:"parameter_report"`
+}
+
+type ParameterReportConfig struct {
+	Enabled         *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	HostFile        string `json:"host_file,omitempty" yaml:"host_file,omitempty"`
+	TokenFile       string `json:"token_file,omitempty" yaml:"token_file,omitempty"`
+	CatalogFile     string `json:"catalog_file,omitempty" yaml:"catalog_file,omitempty"`
+	IntervalSeconds int    `json:"interval_seconds,omitempty" yaml:"interval_seconds,omitempty"`
+	TimeoutSeconds  int    `json:"timeout_seconds,omitempty" yaml:"timeout_seconds,omitempty"`
+}
+
+type ResolvedParameterReportConfig struct {
+	Enabled         bool
+	HostFile        string
+	TokenFile       string
+	CatalogFile     string
+	IntervalSeconds int
+	TimeoutSeconds  int
 }
 
 type InstanceImage struct {
@@ -53,6 +72,40 @@ func (c *GlobalConfig) GetHostResolveMode() string {
 	default:
 		return HostResolveModeDNS
 	}
+}
+
+func (c *GlobalConfig) GetParameterReportConfig() ResolvedParameterReportConfig {
+	out := ResolvedParameterReportConfig{
+		Enabled:         true,
+		HostFile:        naming.ParameterReportHostPath,
+		TokenFile:       naming.ParameterReportTokenPath,
+		CatalogFile:     naming.ParameterReportCatalogPath,
+		IntervalSeconds: 60,
+		TimeoutSeconds:  10,
+	}
+	if c == nil {
+		return out
+	}
+	cfg := c.ParameterReport
+	if cfg.Enabled != nil {
+		out.Enabled = *cfg.Enabled
+	}
+	if strings.TrimSpace(cfg.HostFile) != "" {
+		out.HostFile = strings.TrimSpace(cfg.HostFile)
+	}
+	if strings.TrimSpace(cfg.TokenFile) != "" {
+		out.TokenFile = strings.TrimSpace(cfg.TokenFile)
+	}
+	if strings.TrimSpace(cfg.CatalogFile) != "" {
+		out.CatalogFile = strings.TrimSpace(cfg.CatalogFile)
+	}
+	if cfg.IntervalSeconds > 0 {
+		out.IntervalSeconds = cfg.IntervalSeconds
+	}
+	if cfg.TimeoutSeconds > 0 {
+		out.TimeoutSeconds = cfg.TimeoutSeconds
+	}
+	return out
 }
 
 func (c *GlobalConfig) GetDBConfig(engine string, fullVersion string) map[string]string {

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/sqc157400661/kdb/internal/naming"
+	"github.com/sqc157400661/util"
+)
+
+func TestGetParameterReportConfigDefaults(t *testing.T) {
+	got := (&GlobalConfig{}).GetParameterReportConfig()
+	if !got.Enabled {
+		t.Fatalf("parameter reporter should be enabled by default")
+	}
+	if got.HostFile != naming.ParameterReportHostPath {
+		t.Fatalf("unexpected host file: %s", got.HostFile)
+	}
+	if got.TokenFile != naming.ParameterReportTokenPath {
+		t.Fatalf("unexpected token file: %s", got.TokenFile)
+	}
+	if got.CatalogFile != naming.ParameterReportCatalogPath {
+		t.Fatalf("unexpected catalog file: %s", got.CatalogFile)
+	}
+	if got.IntervalSeconds != 60 || got.TimeoutSeconds != 10 {
+		t.Fatalf("unexpected defaults: %#v", got)
+	}
+}
+
+func TestGetParameterReportConfigOverrides(t *testing.T) {
+	cfg := &GlobalConfig{ParameterReport: ParameterReportConfig{
+		Enabled:         util.Bool(false),
+		HostFile:        "/custom/report_host",
+		TokenFile:       "/custom/report_token",
+		CatalogFile:     "/custom/catalog.json",
+		IntervalSeconds: 30,
+		TimeoutSeconds:  5,
+	}}
+	got := cfg.GetParameterReportConfig()
+	if got.Enabled {
+		t.Fatalf("expected disabled reporter")
+	}
+	if got.HostFile != "/custom/report_host" ||
+		got.TokenFile != "/custom/report_token" ||
+		got.CatalogFile != "/custom/catalog.json" {
+		t.Fatalf("unexpected custom paths: %#v", got)
+	}
+	if got.IntervalSeconds != 30 || got.TimeoutSeconds != 5 {
+		t.Fatalf("unexpected custom timings: %#v", got)
+	}
+}

--- a/internal/config/tmpl/instance.tmpl
+++ b/internal/config/tmpl/instance.tmpl
@@ -34,3 +34,10 @@ backup:
   crontab:
   oss: {}
   s3: {}
+parameter_report:
+  enabled: {{.ParameterReportEnabled}}
+  host_file: {{.ParameterReportHostFile}}
+  token_file: {{.ParameterReportTokenFile}}
+  catalog_file: {{.ParameterReportCatalogFile}}
+  interval_seconds: {{.ParameterReportIntervalSeconds}}
+  timeout_seconds: {{.ParameterReportTimeoutSeconds}}

--- a/internal/generate/pod.go
+++ b/internal/generate/pod.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sqc157400661/kdb/internal/naming"
 	"github.com/sqc157400661/kdb/internal/security"
 	"github.com/sqc157400661/kdb/pkg/reconcile/context"
+	"github.com/sqc157400661/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -78,6 +79,7 @@ func instanceVolsIntent(rc *context.InstanceContext, sts *appsv1.StatefulSet) (m
 							}},
 						},
 					},
+					parameterReportSecretProjection(),
 				},
 			},
 		},
@@ -152,6 +154,31 @@ func instanceVolsIntent(rc *context.InstanceContext, sts *appsv1.StatefulSet) (m
 			MountPath: "/tmp",
 		})
 	return
+}
+
+func parameterReportSecretProjection() corev1.VolumeProjection {
+	return corev1.VolumeProjection{
+		Secret: &corev1.SecretProjection{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: naming.GlobalConfigSecret,
+			},
+			Optional: util.Bool(true),
+			Items: []corev1.KeyToPath{
+				{
+					Key:  naming.ParameterReportHostSecretKey,
+					Path: naming.ParameterReportHostSecretKey,
+				},
+				{
+					Key:  naming.ParameterReportTokenSecretKey,
+					Path: naming.ParameterReportTokenSecretKey,
+				},
+				{
+					Key:  naming.ParameterReportCatalogSecretKey,
+					Path: naming.ParameterReportCatalogSecretKey,
+				},
+			},
+		},
+	}
 }
 
 func instanceContainer(rc *context.InstanceContext, statefulSetName string, mounts []corev1.VolumeMount) (initContainers []corev1.Container, containers []corev1.Container) {

--- a/internal/generate/pod_test.go
+++ b/internal/generate/pod_test.go
@@ -9,6 +9,36 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func TestParameterReportSecretProjection(t *testing.T) {
+	projection := parameterReportSecretProjection()
+	if projection.Secret == nil {
+		t.Fatalf("expected secret projection")
+	}
+	if projection.Secret.Name != naming.GlobalConfigSecret {
+		t.Fatalf("unexpected secret name: %s", projection.Secret.Name)
+	}
+	if projection.Secret.Optional == nil || !*projection.Secret.Optional {
+		t.Fatalf("parameter report secret projection should be optional")
+	}
+	want := map[string]string{
+		naming.ParameterReportHostSecretKey:    naming.ParameterReportHostSecretKey,
+		naming.ParameterReportTokenSecretKey:   naming.ParameterReportTokenSecretKey,
+		naming.ParameterReportCatalogSecretKey: naming.ParameterReportCatalogSecretKey,
+	}
+	if len(projection.Secret.Items) != len(want) {
+		t.Fatalf("unexpected projection items: %#v", projection.Secret.Items)
+	}
+	for _, item := range projection.Secret.Items {
+		if want[item.Key] != item.Path {
+			t.Fatalf("unexpected key/path: %#v", item)
+		}
+		delete(want, item.Key)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing projection items: %#v", want)
+	}
+}
+
 func TestMySQLExporterEnabled(t *testing.T) {
 	instance := &v1.KDBInstance{}
 	instance.Spec.Engine = naming.MySQLEngine

--- a/internal/naming/common.go
+++ b/internal/naming/common.go
@@ -16,6 +16,16 @@ const (
 )
 
 const (
+	ParameterReportHostSecretKey    = "report_host"
+	ParameterReportTokenSecretKey   = "report_token"
+	ParameterReportCatalogSecretKey = "parameter_catalog.json"
+
+	ParameterReportHostPath    = ConfigMountPath + "/" + ParameterReportHostSecretKey
+	ParameterReportTokenPath   = ConfigMountPath + "/" + ParameterReportTokenSecretKey
+	ParameterReportCatalogPath = ConfigMountPath + "/" + ParameterReportCatalogSecretKey
+)
+
+const (
 	// DataMountPath is where to mount the main data volume.
 	DataMountPath = "/kdbdata"
 

--- a/pkg/reconcile/steps/mysql/instance.go
+++ b/pkg/reconcile/steps/mysql/instance.go
@@ -58,25 +58,32 @@ func (s *InstanceStepManager) SetInstanceConfig() kube.BindFunc {
 			if mgrConfig.Enabled {
 				mgrLocalAddress = topology.BuildMGRLocalAddress(instance, int(mgrConfig.BootstrapOrdinal), mgrConfig.GroupPort)
 			}
+			parameterReport := globalConfig.GetParameterReportConfig()
 			// create config
 			util.StringMap(&instanceConfigMap.Data)
 			configStr, err := util.SafeTemplateFill(config.InstanceConfigTmpl, map[string]any{
-				"RootUser":            globalConfig.DB.RootUser,
-				"RootPassword":        globalConfig.DB.RootPassword,
-				"ReplUser":            globalConfig.DB.ReplUser,
-				"ReplPassword":        globalConfig.DB.ReplPassword,
-				"CurrentVersion":      naming.CurrentConfigVersion(instance),
-				"UpdateVersion":       naming.UpdateConfigVersion(instance),
-				"Replications":        replications,
-				"DeployArch":          naming.DeployArch(instance),
-				"MGREnabled":          mgrConfig.Enabled,
-				"MGRMode":             mgrConfig.Mode,
-				"MGRGroupName":        mgrConfig.GroupName,
-				"MGRLocalAddress":     mgrLocalAddress,
-				"MGRSeeds":            mgrConfig.Seeds,
-				"MGRBootstrap":        mgrConfig.Enabled,
-				"MGRBootstrapOrdinal": mgrConfig.BootstrapOrdinal,
-				"MGRGroupPort":        mgrConfig.GroupPort,
+				"RootUser":                       globalConfig.DB.RootUser,
+				"RootPassword":                   globalConfig.DB.RootPassword,
+				"ReplUser":                       globalConfig.DB.ReplUser,
+				"ReplPassword":                   globalConfig.DB.ReplPassword,
+				"CurrentVersion":                 naming.CurrentConfigVersion(instance),
+				"UpdateVersion":                  naming.UpdateConfigVersion(instance),
+				"Replications":                   replications,
+				"DeployArch":                     naming.DeployArch(instance),
+				"MGREnabled":                     mgrConfig.Enabled,
+				"MGRMode":                        mgrConfig.Mode,
+				"MGRGroupName":                   mgrConfig.GroupName,
+				"MGRLocalAddress":                mgrLocalAddress,
+				"MGRSeeds":                       mgrConfig.Seeds,
+				"MGRBootstrap":                   mgrConfig.Enabled,
+				"MGRBootstrapOrdinal":            mgrConfig.BootstrapOrdinal,
+				"MGRGroupPort":                   mgrConfig.GroupPort,
+				"ParameterReportEnabled":         parameterReport.Enabled,
+				"ParameterReportHostFile":        parameterReport.HostFile,
+				"ParameterReportTokenFile":       parameterReport.TokenFile,
+				"ParameterReportCatalogFile":     parameterReport.CatalogFile,
+				"ParameterReportIntervalSeconds": parameterReport.IntervalSeconds,
+				"ParameterReportTimeoutSeconds":  parameterReport.TimeoutSeconds,
 			})
 			if err != nil {
 				return flow.Error(err, "get instance config err")

--- a/pkg/reconcile/steps/mysql/instance_test.go
+++ b/pkg/reconcile/steps/mysql/instance_test.go
@@ -1,12 +1,15 @@
 package mysql
 
 import (
+	"strings"
 	"testing"
 
 	v1 "github.com/sqc157400661/kdb/apis/kdb.com/v1"
 	"github.com/sqc157400661/kdb/apis/shared"
+	"github.com/sqc157400661/kdb/internal/config"
 	"github.com/sqc157400661/kdb/internal/naming"
 	"github.com/sqc157400661/kdb/internal/topology"
+	"github.com/sqc157400661/util"
 )
 
 func int32ptr(v int32) *int32 { return &v }
@@ -23,5 +26,49 @@ func TestResolveMGRSeeds(t *testing.T) {
 	want := "demo0-0.demo.ns.svc.cluster.local:33061,demo1-0.demo.ns.svc.cluster.local:33061,demo2-0.demo.ns.svc.cluster.local:33061"
 	if seeds != want {
 		t.Fatalf("unexpected seeds: %s", seeds)
+	}
+}
+
+func TestInstanceConfigTemplateIncludesParameterReportPaths(t *testing.T) {
+	report := (&config.GlobalConfig{}).GetParameterReportConfig()
+	got, err := util.SafeTemplateFill(config.InstanceConfigTmpl, map[string]any{
+		"RootUser":                       "root",
+		"RootPassword":                   "root-pass",
+		"ReplUser":                       "repl",
+		"ReplPassword":                   "repl-pass",
+		"CurrentVersion":                 "1",
+		"UpdateVersion":                  "1",
+		"Replications":                   "",
+		"DeployArch":                     naming.MySQLSingleDeployArch,
+		"MGREnabled":                     false,
+		"MGRMode":                        "",
+		"MGRGroupName":                   "",
+		"MGRLocalAddress":                "",
+		"MGRSeeds":                       "",
+		"MGRBootstrap":                   false,
+		"MGRBootstrapOrdinal":            0,
+		"MGRGroupPort":                   0,
+		"ParameterReportEnabled":         report.Enabled,
+		"ParameterReportHostFile":        report.HostFile,
+		"ParameterReportTokenFile":       report.TokenFile,
+		"ParameterReportCatalogFile":     report.CatalogFile,
+		"ParameterReportIntervalSeconds": report.IntervalSeconds,
+		"ParameterReportTimeoutSeconds":  report.TimeoutSeconds,
+	})
+	if err != nil {
+		t.Fatalf("render instance config template: %v", err)
+	}
+	for _, want := range []string{
+		"parameter_report:",
+		"enabled: true",
+		"host_file: " + naming.ParameterReportHostPath,
+		"token_file: " + naming.ParameterReportTokenPath,
+		"catalog_file: " + naming.ParameterReportCatalogPath,
+		"interval_seconds: 60",
+		"timeout_seconds: 10",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered config missing %q:\n%s", want, got)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add MySQL parameter report config to GlobalConfig with defaults for /etc/config/report_host, /etc/config/report_token, and /etc/config/parameter_catalog.json.
- Render parameter_report into the sidecar config with file paths only; the token value is not written into ConfigMap.
- Add optional Secret projection from kdb-global-config for report_host, report_token, and parameter_catalog.json into the existing /etc/config projected volume.
- Add focused unit coverage for report config defaults, template rendering, and Secret projection keys/paths.

## Verification
Passed:
- go test ./internal/config ./internal/generate ./pkg/reconcile/steps/mysql
- go test ./pkg/reconcile/steps
- git diff --check

Known base failure:
- go test ./... still fails in existing internal/security assertions, unrelated to this parameter report projection change.
