### PR TITLE
fix: allow operator to grant instance pod rbac

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,8 +22,12 @@ rules:
   resources:
   - endpoints
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -32,6 +36,15 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -57,8 +70,11 @@ rules:
   resources:
   - serviceaccounts
   verbs:
+  - create
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -97,6 +113,21 @@ rules:
   - kdb.com
   resources:
   - kdbclusters/status
+  verbs:
+  - patch
+- apiGroups:
+  - kdb.com
+  resources:
+  - kdbinstances
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - kdb.com
+  resources:
+  - kdbinstances/status
   verbs:
   - patch
 - apiGroups:
@@ -164,14 +195,20 @@ rules:
   resources:
   - rolebindings
   verbs:
+  - create
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles
   verbs:
+  - create
   - get
   - list
+  - patch
+  - update
   - watch

--- a/hack/sample/operator/role.yaml
+++ b/hack/sample/operator/role.yaml
@@ -40,6 +40,7 @@ rules:
     - get
     - list
     - patch
+    - update
     - watch
 - apiGroups:
     - ''
@@ -74,6 +75,7 @@ rules:
     - get
     - list
     - patch
+    - update
     - watch
 - apiGroups:
     - apps
@@ -175,4 +177,5 @@ rules:
     - get
     - list
     - patch
+    - update
     - watch

--- a/internal/rbac/rbac_test.go
+++ b/internal/rbac/rbac_test.go
@@ -1,0 +1,113 @@
+package rbac
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestKDBInstancePodPermissionsAreGrantableByOperatorManifests(t *testing.T) {
+	operatorRules := loadClusterRoleRules(t, filepath.Join("..", "..", "config", "rbac", "role.yaml"))
+	sampleRules := loadRoleRules(t, filepath.Join("..", "..", "hack", "sample", "operator", "role.yaml"))
+
+	for _, rule := range KDBInstancePodPermissions() {
+		for _, apiGroup := range rule.APIGroups {
+			for _, resource := range rule.Resources {
+				for _, verb := range rule.Verbs {
+					assertRuleAllows(t, "config/rbac/role.yaml", operatorRules, apiGroup, resource, verb)
+					assertRuleAllows(t, "hack/sample/operator/role.yaml", sampleRules, apiGroup, resource, verb)
+				}
+			}
+		}
+	}
+}
+
+func TestOperatorManifestsCanManageInstanceRbacObjects(t *testing.T) {
+	operatorRules := loadClusterRoleRules(t, filepath.Join("..", "..", "config", "rbac", "role.yaml"))
+	sampleRules := loadRoleRules(t, filepath.Join("..", "..", "hack", "sample", "operator", "role.yaml"))
+
+	requiredRules := []struct {
+		apiGroup string
+		resource string
+		verbs    []string
+	}{
+		{
+			apiGroup: "",
+			resource: "serviceaccounts",
+			verbs:    []string{"create", "get", "list", "patch", "update", "watch"},
+		},
+		{
+			apiGroup: "rbac.authorization.k8s.io",
+			resource: "roles",
+			verbs:    []string{"create", "get", "list", "patch", "update", "watch"},
+		},
+		{
+			apiGroup: "rbac.authorization.k8s.io",
+			resource: "rolebindings",
+			verbs:    []string{"create", "get", "list", "patch", "update", "watch"},
+		},
+	}
+
+	for _, rule := range requiredRules {
+		for _, verb := range rule.verbs {
+			assertRuleAllows(t, "config/rbac/role.yaml", operatorRules, rule.apiGroup, rule.resource, verb)
+			assertRuleAllows(t, "hack/sample/operator/role.yaml", sampleRules, rule.apiGroup, rule.resource, verb)
+		}
+	}
+}
+
+func loadClusterRoleRules(t *testing.T, path string) []rbacv1.PolicyRule {
+	t.Helper()
+
+	data := readManifest(t, path)
+	var role rbacv1.ClusterRole
+	if err := yaml.Unmarshal(data, &role); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return role.Rules
+}
+
+func loadRoleRules(t *testing.T, path string) []rbacv1.PolicyRule {
+	t.Helper()
+
+	data := readManifest(t, path)
+	var role rbacv1.Role
+	if err := yaml.Unmarshal(data, &role); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return role.Rules
+}
+
+func readManifest(t *testing.T, path string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}
+
+func assertRuleAllows(t *testing.T, manifest string, rules []rbacv1.PolicyRule, apiGroup, resource, verb string) {
+	t.Helper()
+
+	for _, rule := range rules {
+		if contains(rule.APIGroups, apiGroup) && contains(rule.Resources, resource) && contains(rule.Verbs, verb) {
+			return
+		}
+	}
+
+	t.Fatalf("%s does not grant %q on %q in API group %q", manifest, verb, resource, apiGroup)
+}
+
+func contains(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/instance_controller.go
+++ b/pkg/controller/instance_controller.go
@@ -40,8 +40,8 @@ type KDBInstanceReconciler struct {
 }
 
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=kdb.com,resources=KDBInstances,verbs=get;list;watch
-// +kubebuilder:rbac:groups=kdb.com,resources=KDBInstances/status,verbs=patch
+// +kubebuilder:rbac:groups=kdb.com,resources=kdbinstances,verbs=get;list;patch;watch
+// +kubebuilder:rbac:groups=kdb.com,resources=kdbinstances/status,verbs=patch
 
 // TODO:
 // 1.实例创建后，没有标记role IsMasterPod判断有问题
@@ -99,17 +99,18 @@ func (r *KDBInstanceReconciler) Reconcile(
 	return kube.NewExecutor(logger).Execute(rc, task)
 }
 
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=endpoints,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;patch;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
 


### PR DESCRIPTION
## Summary

- fix operator RBAC annotations and install ClusterRole so the operator can grant the instance Pod Role permissions it creates
- add missing grantable permissions for `endpoints update`, `configmaps update`, `pods patch`, `kdbinstances patch`, and instance RBAC object management
- align the sample operator Role with the same grantability requirements
- add `internal/rbac` regression tests that compare `KDBInstancePodPermissions()` against both operator manifests

## Root Cause

`KDBInstancePodPermissions()` grants instance Pods permissions such as `endpoints update`, but the operator service account did not hold that verb in the installed operator RBAC. Kubernetes prevents a subject from creating a Role that grants permissions the subject does not already hold, so `SetRbacForInstancePod` failed with RBAC escalation protection.

## Verification

- `go test ./internal/rbac`
- `go test ./internal/rbac ./pkg/controller ./pkg/reconcile/steps ./pkg/reconcile/steps/mysql ./pkg/reconcile/steps/pg`
- `git diff --check`

Known baseline issue: `go test ./...` still fails in `internal/security` assertions unrelated to this RBAC change.

## Live Validation Needed

After applying the updated operator RBAC in a test cluster:

```bash
kubectl auth can-i update endpoints --as system:serviceaccount:kdb:kdb -n kdb
kubectl auth can-i patch kdbinstances.kdb.com --as system:serviceaccount:kdb:kdb -n kdb
kubectl auth can-i patch pods --as system:serviceaccount:kdb:kdb -n kdb
kubectl auth can-i update configmaps --as system:serviceaccount:kdb:kdb -n kdb
kubectl auth can-i update roles.rbac.authorization.k8s.io --as system:serviceaccount:kdb:kdb -n kdb
```

Then re-trigger reconcile for `KDBInstance/mysql-sqc-766000` and confirm `SetRbacForInstancePod` no longer logs RBAC escalation errors.
