### PR TITLE
fix: ignore missing KDBInstance during deferred patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.4
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.4.0
@@ -12,6 +13,7 @@ require (
 	github.com/sqc157400661/util v0.0.10
 	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.25.0
+	k8s.io/apiextensions-apiserver v0.25.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0
 	k8s.io/code-generator v0.25.0
@@ -28,6 +30,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/zapr v1.2.4 // indirect
@@ -40,7 +43,6 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -75,7 +77,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.25.0 // indirect
 	k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/pkg/reconcile/context/instance_context.go
+++ b/pkg/reconcile/context/instance_context.go
@@ -153,11 +153,17 @@ func (rc *InstanceContext) DeleteFinalizer(key string) []string {
 // PatchKDBInstanceStatus the function for the updating the KDBInstance status. Returns any error that
 // occurs while attempting to patch the status
 func (rc *InstanceContext) PatchKDBInstanceStatus() error {
+	if rc.oldInstance == nil || rc.instance == nil {
+		return nil
+	}
 	if !equality.Semantic.DeepEqual(rc.oldInstance.Status, rc.instance.Status) {
 		// NOTE: Kubernetes prior to v1.16.10 and v1.17.6 does not track
 		// managed fields on the status subresource: https://issue.k8s.io/88901
 		if err := errors.WithStack(rc.Client().Status().Patch(
 			rc.Context(), rc.instance, client.MergeFrom(rc.oldInstance), rc.Owner())); err != nil {
+			if apierrors.IsNotFound(errors.Cause(err)) {
+				return nil
+			}
 			return err
 		}
 	}
@@ -169,6 +175,9 @@ func (rc *InstanceContext) PatchKDBInstanceStatus() error {
 func (rc *InstanceContext) PatchKDBInstance() error {
 	before := rc.GetOldInstance()
 	instance := rc.GetInstance()
+	if before == nil || instance == nil {
+		return nil
+	}
 	intent := instance.DeepCopy()
 	if equality.Semantic.DeepEqual(intent.Spec, before.Spec) &&
 		equality.Semantic.DeepEqual(intent.ObjectMeta.Labels, before.ObjectMeta.Labels) &&
@@ -176,7 +185,13 @@ func (rc *InstanceContext) PatchKDBInstance() error {
 		return nil
 	}
 	// not support server-side apply
-	return rc.Client().Patch(rc.Context(), intent, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{}))
+	if err := errors.WithStack(rc.Client().Patch(rc.Context(), intent, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{}))); err != nil {
+		if apierrors.IsNotFound(errors.Cause(err)) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (rc *InstanceContext) SetClusterServiceAccount(sa *corev1.ServiceAccount) {

--- a/pkg/reconcile/context/instance_context_test.go
+++ b/pkg/reconcile/context/instance_context_test.go
@@ -1,0 +1,75 @@
+package context
+
+import (
+	stdctx "context"
+	"testing"
+
+	"github.com/sqc157400661/helper/kube"
+	v1 "github.com/sqc157400661/kdb/apis/kdb.com/v1"
+	"github.com/sqc157400661/kdb/apis/shared"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestPatchKDBInstanceStatusIgnoresNotFound(t *testing.T) {
+	rc := newTestInstanceContext(t, "mysql-sqc-766000")
+	old := testKDBInstance("mysql-sqc-766000", "kdb")
+	instance := old.DeepCopy()
+	instance.Status.Message = "creating"
+	rc.oldInstance = old
+	rc.instance = instance
+
+	if err := rc.PatchKDBInstanceStatus(); err != nil {
+		t.Fatalf("PatchKDBInstanceStatus() should ignore not found: %v", err)
+	}
+}
+
+func TestPatchKDBInstanceIgnoresNotFound(t *testing.T) {
+	rc := newTestInstanceContext(t, "mysql-sqc-766000")
+	old := testKDBInstance("mysql-sqc-766000", "kdb")
+	instance := old.DeepCopy()
+	replicas := int32(2)
+	instance.Spec.InstanceSet.Replicas = &replicas
+	rc.oldInstance = old
+	rc.instance = instance
+
+	if err := rc.PatchKDBInstance(); err != nil {
+		t.Fatalf("PatchKDBInstance() should ignore not found: %v", err)
+	}
+}
+
+func newTestInstanceContext(t *testing.T, name string) *InstanceContext {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add kdb scheme: %v", err)
+	}
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+	helper := kube.NewDefaultReconcileHelper(kubeClient, nil, nil, scheme)
+	base := kube.NewBaseReconcileContext(
+		helper,
+		stdctx.Background(),
+		reconcile.Request{NamespacedName: client.ObjectKey{Name: name, Namespace: "kdb"}},
+		client.FieldOwner("kdb-test"),
+		record.NewFakeRecorder(1),
+	)
+	return NewInstanceContext(base)
+}
+
+func testKDBInstance(name, namespace string) *v1.KDBInstance {
+	replicas := int32(1)
+	return &v1.KDBInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, ResourceVersion: "1"},
+		Spec: v1.KDBInstanceSpec{
+			InstanceSet:   shared.InstanceSetSpec{Replicas: &replicas},
+			Engine:        "mysql",
+			EngineVersion: "8.0",
+		},
+	}
+}

--- a/work_logs/xiaomihu/20260620-fix-instance-notfound-patch-state.yaml
+++ b/work_logs/xiaomihu/20260620-fix-instance-notfound-patch-state.yaml
@@ -1,0 +1,22 @@
+task: fix-instance-notfound-patch
+owner: xiaomihu
+status: in_progress
+branch: feature-fix-instance-notfound-patch
+target_branch: develop
+started_at: "2026-06-20T13:28:25+08:00"
+progress_checklist:
+  - item: inspect operator not found stack
+    status: completed
+  - item: harden deferred patch paths
+    status: completed
+  - item: add context regression tests
+    status: completed
+  - item: run checks
+    status: completed
+  - item: push and merge to develop
+    status: pending
+deliverables:
+  - pkg/reconcile/context/instance_context.go
+  - pkg/reconcile/context/instance_context_test.go
+blockers: []
+next_action: push branch and prepare develop merge path

--- a/work_logs/xiaomihu/20260620-fix-instance-notfound-patch-task-list.md
+++ b/work_logs/xiaomihu/20260620-fix-instance-notfound-patch-task-list.md
@@ -1,0 +1,21 @@
+# 2026-06-20 KDBInstance NotFound Patch Handling
+
+## Goal
+
+Prevent the KDB operator from treating deferred KDBInstance patch attempts as reconcile failures when the CR has already disappeared.
+
+## Task List
+
+- [x] Inspect the operator error stack from `PatchKDBInstanceStatus`.
+- [x] Review `InstanceContext` patch paths used by deferred reconcile steps.
+- [x] Ignore Kubernetes `NotFound` errors from status and object patch operations.
+- [x] Add regression tests for missing KDBInstance during deferred patch.
+- [x] Run the relevant Go checks.
+- [ ] Push the fix branch and prepare the merge path into `develop`.
+
+## Notes
+
+- The operator log showed `kdbinstances.kdb.com "mysql-sqc-766000" not found` from a deferred status patch.
+- This can happen when a reconcile loaded the CR and it was deleted before deferred patch execution.
+- The fix keeps other errors visible while making missing CR patches no-op.
+- `go test ./...` still exposes pre-existing `internal/security` assertions unrelated to this patch.


### PR DESCRIPTION
## Summary
- ignore Kubernetes NotFound from deferred KDBInstance status/object patch paths
- guard nil instance snapshots before deferred patching
- add regression coverage for missing KDBInstance patch attempts
- add xiaomihu work log state for the incident

## Verification
- go test ./pkg/reconcile/context
- go test ./... *(fails in pre-existing internal/security assertions unrelated to this patch: RunAsNonRoot, capabilities, AllowPrivilegeEscalation, ReadOnlyRootFilesystem)*

## Risk
- Other Kubernetes patch errors still surface normally.
- The change only turns already-missing CR patch attempts into no-op behavior.