### PR TITLE
fix: collect MySQL file logs in KDBLogSystem collector

### DIFF
--- a/pkg/controller/log_system_controller.go
+++ b/pkg/controller/log_system_controller.go
@@ -122,8 +122,10 @@ func (r *KDBLogSystemReconciler) reconcileConfigMap(ctx context.Context, logSyst
 		}
 		cm.Labels = logSystemLabels(logSystem)
 		cm.Data = map[string]string{
-			"backend.json": string(raw),
-			"configHash":   hash,
+			"backend.json":    string(raw),
+			"configHash":      hash,
+			"fluent-bit.conf": renderLogSystemFluentBitConfig(logSystem.Spec.Endpoints.Write),
+			"parsers.conf":    renderLogSystemFluentBitParsers(),
 		}
 		return nil
 	})
@@ -250,7 +252,9 @@ func (r *KDBLogSystemReconciler) reconcileCollectorDaemonSet(ctx context.Context
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: "backend-config", MountPath: "/etc/kdb/log-system", ReadOnly: true},
+				{Name: "backend-config", MountPath: "/fluent-bit/etc", ReadOnly: true},
 				{Name: "varlog", MountPath: "/var/log", ReadOnly: true},
+				{Name: "kubelet-pods", MountPath: "/var/lib/kubelet/pods", ReadOnly: true},
 			},
 		}}
 		ds.Spec.Template.Spec.Volumes = []corev1.Volume{
@@ -264,10 +268,74 @@ func (r *KDBLogSystemReconciler) reconcileCollectorDaemonSet(ctx context.Context
 				Name:         "varlog",
 				VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/log"}},
 			},
+			{
+				Name:         "kubelet-pods",
+				VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/kubelet/pods"}},
+			},
 		}
 		return nil
 	})
 	return ds, err
+}
+
+func renderLogSystemFluentBitConfig(writeEndpoint string) string {
+	return fmt.Sprintf(`[SERVICE]
+    Flush        5
+    Daemon       Off
+    Log_Level    info
+    Parsers_File parsers.conf
+
+[INPUT]
+    Name              tail
+    Path              /var/log/containers/*.log
+    Parser            cri
+    Tag               kube.*
+    Path_Key          file_path
+    Refresh_Interval  5
+    Mem_Buf_Limit     50MB
+    Skip_Long_Lines   On
+
+[INPUT]
+    Name              tail
+    Path              /var/lib/kubelet/pods/*/volumes/*/*/log/my-error.log,/var/lib/kubelet/pods/*/volumes/*/*/log/slow.log
+    Parser            mysql_file
+    Tag               kdb.mysql.file
+    Path_Key          file_path
+    Refresh_Interval  5
+    Mem_Buf_Limit     50MB
+    Skip_Long_Lines   On
+
+[FILTER]
+    Name                kubernetes
+    Match               kube.*
+    Merge_Log           On
+    Keep_Log            Off
+    K8S-Logging.Parser  On
+    K8S-Logging.Exclude Off
+
+[OUTPUT]
+    Name        loki
+    Match       *
+    Url         %s
+    Labels      job=kdb,source=fluent-bit
+    Label_Keys  $kubernetes['namespace_name'],$kubernetes['pod_name'],$kubernetes['container_name'],$kubernetes['host'],$file_path
+    Line_Format json
+`, writeEndpoint)
+}
+
+func renderLogSystemFluentBitParsers() string {
+	return `[PARSER]
+    Name        cri
+    Format      regex
+    Regex       ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+
+[PARSER]
+    Name        mysql_file
+    Format      regex
+    Regex       ^(?<log>.*)$
+`
 }
 
 func (r *KDBLogSystemReconciler) patchStatus(ctx context.Context, logSystem *v1.KDBLogSystem, phase string, readyReplicas int32, configHash, message string, requeueAfter time.Duration) (ctrl.Result, error) {

--- a/pkg/controller/log_system_controller_test.go
+++ b/pkg/controller/log_system_controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	v1 "github.com/sqc157400661/kdb/apis/kdb.com/v1"
@@ -52,6 +53,25 @@ func TestIsLogSystemDeploymentReadyRequiresCurrentRollout(t *testing.T) {
 				t.Fatalf("isLogSystemDeploymentReady() = %v, want %v", got, tt.wantReady)
 			}
 		})
+	}
+}
+
+func TestRenderLogSystemFluentBitConfigCollectsContainerAndMySQLFileLogs(t *testing.T) {
+	conf := renderLogSystemFluentBitConfig("http://loki.kdb.svc:3100/loki/api/v1/push")
+	for _, want := range []string{
+		"Url         http://loki.kdb.svc:3100/loki/api/v1/push",
+		"/var/log/containers/*.log",
+		"/var/lib/kubelet/pods/*/volumes/*/*/log/my-error.log",
+		"/var/lib/kubelet/pods/*/volumes/*/*/log/slow.log",
+		"Label_Keys  $kubernetes['namespace_name'],$kubernetes['pod_name'],$kubernetes['container_name'],$kubernetes['host'],$file_path",
+	} {
+		if !strings.Contains(conf, want) {
+			t.Fatalf("fluent-bit config missing %q:\n%s", want, conf)
+		}
+	}
+	parsers := renderLogSystemFluentBitParsers()
+	if !strings.Contains(parsers, "Name        cri") || !strings.Contains(parsers, "Name        mysql_file") {
+		t.Fatalf("parsers missing cri or mysql_file parser:\n%s", parsers)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add fluent-bit config to KDBLogSystem ConfigMap
- collect both container stdout/stderr and MySQL my-error.log/slow.log files from kubelet pod volume paths
- mount /var/lib/kubelet/pods read-only in the collector DaemonSet

## Verification
- go test ./pkg/controller

## Deployment note
- Existing KDBLogSystem resources need reconcile/collector rollout to pick up the new config and hostPath mount.