### PR TITLE
Fix Fluent Bit Loki output config

### DIFF
--- a/pkg/controller/log_system_controller.go
+++ b/pkg/controller/log_system_controller.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"time"
 
 	v1 "github.com/sqc157400661/kdb/apis/kdb.com/v1"
@@ -316,11 +317,38 @@ func renderLogSystemFluentBitConfig(writeEndpoint string) string {
 [OUTPUT]
     Name        loki
     Match       *
-    Url         %s
+%s
     Labels      job=kdb,source=fluent-bit
     Label_Keys  $kubernetes['namespace_name'],$kubernetes['pod_name'],$kubernetes['container_name'],$kubernetes['host'],$file_path
     Line_Format json
-`, writeEndpoint)
+`, renderLogSystemLokiOutputEndpoint(writeEndpoint))
+}
+
+func renderLogSystemLokiOutputEndpoint(writeEndpoint string) string {
+	parsed, err := url.Parse(writeEndpoint)
+	if err != nil || parsed.Hostname() == "" {
+		return fmt.Sprintf("    URI         %s", writeEndpoint)
+	}
+	port := parsed.Port()
+	if port == "" {
+		if parsed.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	uri := parsed.EscapedPath()
+	if uri == "" {
+		uri = "/loki/api/v1/push"
+	}
+	if parsed.RawQuery != "" {
+		uri += "?" + parsed.RawQuery
+	}
+	tls := ""
+	if parsed.Scheme == "https" {
+		tls = "\n    TLS         On"
+	}
+	return fmt.Sprintf("    Host        %s\n    Port        %s\n    URI         %s%s", parsed.Hostname(), port, uri, tls)
 }
 
 func renderLogSystemFluentBitParsers() string {

--- a/pkg/controller/log_system_controller_test.go
+++ b/pkg/controller/log_system_controller_test.go
@@ -59,7 +59,9 @@ func TestIsLogSystemDeploymentReadyRequiresCurrentRollout(t *testing.T) {
 func TestRenderLogSystemFluentBitConfigCollectsContainerAndMySQLFileLogs(t *testing.T) {
 	conf := renderLogSystemFluentBitConfig("http://loki.kdb.svc:3100/loki/api/v1/push")
 	for _, want := range []string{
-		"Url         http://loki.kdb.svc:3100/loki/api/v1/push",
+		"Host        loki.kdb.svc",
+		"Port        3100",
+		"URI         /loki/api/v1/push",
 		"/var/log/containers/*.log",
 		"/var/lib/kubelet/pods/*/volumes/*/*/log/*.log",
 		"/var/lib/kubelet/pods/*/volumes/*/*/logs/*.log",
@@ -72,6 +74,23 @@ func TestRenderLogSystemFluentBitConfigCollectsContainerAndMySQLFileLogs(t *test
 	parsers := renderLogSystemFluentBitParsers()
 	if !strings.Contains(parsers, "Name        cri") || !strings.Contains(parsers, "Name        mysql_file") {
 		t.Fatalf("parsers missing cri or mysql_file parser:\n%s", parsers)
+	}
+}
+
+func TestRenderLogSystemLokiOutputEndpointEnablesTLSForHTTPS(t *testing.T) {
+	conf := renderLogSystemLokiOutputEndpoint("https://loki.example.com/loki/api/v1/push")
+	for _, want := range []string{
+		"Host        loki.example.com",
+		"Port        443",
+		"URI         /loki/api/v1/push",
+		"TLS         On",
+	} {
+		if !strings.Contains(conf, want) {
+			t.Fatalf("loki endpoint config missing %q:\n%s", want, conf)
+		}
+	}
+	if strings.Contains(conf, "Url") {
+		t.Fatalf("loki endpoint config must not use unsupported Url property:\n%s", conf)
 	}
 }
 


### PR DESCRIPTION
## Summary
- render Loki output with Host/Port/URI instead of unsupported Url
- preserve TLS for HTTPS write endpoints
- add regression coverage for collector config rendering

## Verification
- go test ./pkg/controller